### PR TITLE
Fix code scanning alert no. 487: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2002,7 +2002,7 @@
         getColumnData: function (e, t, r, o, s) {
           if ("object" != typeof t || null === t) return t;
           var a,
-            n = (e = A(e)[0]).config,
+            n = (e = A.find(e)[0]).config,
             i = s || n.$headers,
             d =
               (n.$headerIndexed && n.$headerIndexed[r]) ||


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/wesnoth/security/code-scanning/487](https://github.com/cooljeanius/wesnoth/security/code-scanning/487)

To fix the problem, we need to ensure that the input used in jQuery selectors is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the input to the jQuery constructor. Additionally, we should document the options that can lead to XSS attacks and ensure that any dynamic HTML construction is properly sanitized.

- Replace the direct use of `A(e)` with `A.find(e)` in the `getColumnData` function.
- Ensure that any other similar uses of jQuery selectors are also updated to prevent XSS vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
