### PR TITLE
Fix code scanning alert no. 481: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -1982,7 +1982,7 @@
           var o,
             s,
             a = "",
-            n = A(e);
+            n = A.find(e);
           return n.length
             ? ((o = !!A.metadata && n.metadata()),
               (s = " " + (n.attr("class") || "")),


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/wesnoth/security/code-scanning/481](https://github.com/cooljeanius/wesnoth/security/code-scanning/481)

To fix the problem, we need to ensure that the input used in the jQuery selector is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of directly passing the input to `jQuery`. This change will prevent the input from being interpreted as HTML, thus mitigating the XSS risk.

- **General Fix:** Use `jQuery.find` to interpret the input as a CSS selector.
- **Detailed Fix:** Replace the direct use of `A(e)` with `A.find(e)` on line 1985.
- **Files/Regions/Lines to Change:** Modify the code in `data/tools/addon_manager/tablesorter.js` around line 1985.
- **Needed Changes:** No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
