### PR TITLE
Fix code scanning alert no. 480: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -1714,7 +1714,7 @@
             a,
             n,
             i,
-            d = (e = A(e)[0]).config,
+            d = (e = A.find(e)[0]).config,
             l = L.debug(d, "core"),
             c = [];
           if (


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/wesnoth/security/code-scanning/480](https://github.com/cooljeanius/wesnoth/security/code-scanning/480)

To fix the problem, we need to ensure that the input provided to the jQuery selector is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery` to interpret the input strictly as a CSS selector. Additionally, we should document the options that can lead to XSS attacks and ensure that any dynamic HTML construction is properly sanitized.

- Replace instances where `A(e)` is used to select elements with `A.find(e)` to ensure the input is treated as a CSS selector.
- Ensure that any other dynamic HTML construction is properly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
