### PR TITLE
Fix code scanning alert no. 479: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -891,7 +891,7 @@
             c = a.$table
               .find("tfoot tr")
               .children("td, th")
-              .add(A(a.namespace + "_extra_headers"))
+              .add(A(escapeHtml(a.namespace) + "_extra_headers"))
               .removeClass(i.join(" ")),
             g = a.$headers
               .add(A("thead " + a.namespace + "_extra_headers"))
@@ -2460,6 +2460,21 @@
             }
           },
         });
+    // Utility function to escape HTML special characters
+    function escapeHtml(string) {
+      return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+        return {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+          '/': '&#x2F;',
+          '`': '&#x60;',
+          '=': '&#x3D;'
+        }[s];
+      });
+    }
     })(e),
     e.tablesorter
   );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/wesnoth/security/code-scanning/479](https://github.com/cooljeanius/wesnoth/security/code-scanning/479)

To fix the problem, we need to ensure that the `namespace` property is sanitized before it is used in dynamic HTML construction. This can be done by escaping any potentially dangerous characters in the `namespace` string to prevent XSS attacks.

The best way to fix this without changing existing functionality is to sanitize the `namespace` property right before it is used in the dynamic HTML construction. We can use a simple utility function to escape any HTML special characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
