### PR TITLE
Update some CI files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,11 @@ on:
       - pr/*
       - dependabot/*
       - autofix/alert-*
+      - alert/autofix-*
       - ruff_unsafe
+      - android-support
   pull_request:
-    # The branches below must be a subset of the branches above
+    # The branches below must be a subset of the branches above:
     branches:
       - master
       - main
@@ -20,7 +22,10 @@ on:
       - pr/*
       - dependabot/*
       - autofix/alert-*
+      - alert/autofix-*
       - ruff_unsafe
+      - android-support
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -30,7 +35,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     permissions:
       actions: read
@@ -71,14 +76,15 @@ jobs:
       - name: Install dependencies
         if: matrix.language == 'cpp'
         run: |
-          sudo apt update
-          sudo apt install scons libboost-system1.74-dev \
-            libboost-filesystem1.74-dev libboost-iostreams1.74-dev \
-            libboost-serialization1.74-dev libboost-locale1.74-dev \
-            libboost-regex1.74-dev libboost-random1.74-dev \
-            libboost-program-options1.74-dev libboost-thread1.74-dev \
-            libboost-context1.74-dev libboost-test-dev \
-            libboost-coroutine1.74-dev libasio-dev libsdl2-dev \
+          utils/autorevision.sh -t h > src/revision.h
+          sudo apt update && sync && echo "updated"
+          sudo apt install scons libboost-system1.83-dev \
+            libboost-filesystem1.83-dev libboost-iostreams1.83-dev \
+            libboost-serialization1.83-dev libboost-locale1.83-dev \
+            libboost-regex1.83-dev libboost-random1.83-dev \
+            libboost-program-options1.83-dev libboost-thread1.83-dev \
+            libboost-context1.83-dev libboost-test-dev \
+            libboost-coroutine1.83-dev libasio-dev libsdl2-dev \
             libsdl2-image-dev libsdl2-mixer-dev libvorbis-dev \
             libpango1.0-dev libssl-dev libcurl4-openssl-dev
       # Autobuild attempts to build any compiled languages

--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -35,6 +35,7 @@
                 {
                     "type": "archive",
                     "url": "https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.bz2",
+		    "mirror-url": "https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2",
                     "sha256": "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba"
                 }
             ],


### PR DESCRIPTION
use `mirror-url` key, as suggested by @loonycyborg in wesnoth/wesnoth#9690