### PR TITLE
Potential fix for code scanning alert no. 431: Use of insecure SSL/TLS version

### DIFF
--- a/data/tools/wesnoth/campaignserver_client.py
+++ b/data/tools/wesnoth/campaignserver_client.py
@@ -86,9 +86,11 @@ class CampaignClient:
 
         if self.secure:
             print("Attempting to connect to the server using SSL/TLS", file=sys.stderr)
-            self.context = ssl.create_default_context()
+            self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            self.context.check_hostname = True
+            self.context.verify_mode = ssl.CERT_REQUIRED
+            self.context.load_default_certs()
             self.context.minimum_version = ssl.TLSVersion.TLSv1_2
-            self.context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
         else:
             self.context = None
 


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/431](https://github.com/cooljeanius/wesnoth/security/code-scanning/431)

To fix this cleanly, construct the SSL context with an explicitly modern protocol baseline instead of relying on defaults. Replace:

- `ssl.create_default_context()`

with:

- `ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)`

Then keep certificate verification defaults (`verify_mode = ssl.CERT_REQUIRED`, `check_hostname = True`, and load default CAs), and enforce TLS 1.2+ via `minimum_version`.

**Best single fix in this file/region** (inside `CampaignClient.__init__`, secure branch around lines 87–92):
1. Replace context creation call with `SSLContext(ssl.PROTOCOL_TLS_CLIENT)`.
2. Set `check_hostname` and `verify_mode` explicitly.
3. Call `load_default_certs()`.
4. Keep `minimum_version = TLSv1_2`.
5. Remove legacy `OP_NO_TLSv1 | OP_NO_TLSv1_1` bitmask (no longer needed when minimum version is set explicitly).

This addresses both alert variants at the same source.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
