### PR TITLE
Potential fix for code scanning alert no. 554: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2032,7 +2032,7 @@
             : e.add(s).removeClass(L.css.processing + " " + o.cssProcessing);
         },
         processTbody: function (e, t, r) {
-          if (!(e = A.find(e)[0])) return;
+          if (!((e = A(e)[0]) && 1 === e.nodeType)) return;
           if (r)
             return (
               (e.isProcessing = !0),

--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2032,7 +2032,8 @@
             : e.add(s).removeClass(L.css.processing + " " + o.cssProcessing);
         },
         processTbody: function (e, t, r) {
-          if (!((e = A(e)[0]) && 1 === e.nodeType)) return;
+          e = e && e.jquery ? e[0] : e;
+          if (!(e && 1 === e.nodeType)) return;
           if (r)
             return (
               (e.isProcessing = !0),

--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2032,13 +2032,14 @@
             : e.add(s).removeClass(L.css.processing + " " + o.cssProcessing);
         },
         processTbody: function (e, t, r) {
-          if (((e = A.find(e)[0]), r))
+          if (!(e = A.find(e)[0])) return;
+          if (r)
             return (
               (e.isProcessing = !0),
               t.before('<colgroup class="tablesorter-savemyplace"/>'),
               A.fn.detach ? t.detach() : t.remove()
             );
-          var o = A(e).find("colgroup.tablesorter-savemyplace");
+          var o = A(A.find("colgroup.tablesorter-savemyplace", e));
           t.insertAfter(o), o.remove(), (e.isProcessing = !1);
         },
         clearTableBody: function (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/554](https://github.com/cooljeanius/wesnoth/security/code-scanning/554)

To fix this safely without changing intended behavior, constrain `processTbody` to operate only on DOM elements and avoid passing potentially string input into `A(...)` as a constructor argument.

Best concrete fix in `data/tools/addon_manager/tablesorter.js`:
- In `processTbody`, resolve `e` via `A.find(e)[0]` as it already does.
- Add a guard that returns early if no element is resolved.
- Replace `A(e).find("colgroup.tablesorter-savemyplace")` with `A.find("colgroup.tablesorter-savemyplace", e)` so lookup is always CSS-selector-in-context, not constructor interpretation.

This preserves functionality (finding the saved colgroup under the resolved table element) while removing the unsafe plugin pattern flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
