### PR TITLE
Potential fix for code scanning alert no. 553: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2006,7 +2006,9 @@
             i = s || n.$headers,
             l =
               "string" == typeof i
-                ? A(A.find(i, e))
+                ? -1 < i.indexOf("<")
+                  ? A()
+                  : A(A.find(i, e))
                 : A(i && i.jquery ? i.toArray() : i),
             c = l.length ? l : n.$headers,
             d =

--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2006,10 +2006,16 @@
             i = s || n.$headers,
             l =
               "string" == typeof i
-                ? -1 < i.indexOf("<")
-                  ? A()
-                  : A(A.find(i, e))
-                : A(i && i.jquery ? i.toArray() : i),
+                ? ((i = A.trim(i)),
+                  -1 < i.indexOf("<") ||
+                  !/^[\w\s\-#.:,[\]\(\)="'>+~*|^$\\]+$/.test(i)
+                    ? A()
+                    : A(A.find(i, e)))
+                : i && i.jquery
+                  ? i
+                  : i && ("number" == typeof i.length || i.nodeType)
+                    ? A(i)
+                    : A(),
             c = l.length ? l : n.$headers,
             d =
               (n.$headerIndexed && n.$headerIndexed[r]) ||

--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2008,6 +2008,7 @@
               "string" == typeof i
                 ? ((i = A.trim(i)),
                   -1 < i.indexOf("<") ||
+                  -1 < i.indexOf(":") ||
                   !/^[\w\s\-#.:,[\]\(\)="'>+~*|^$\\]+$/.test(i)
                     ? A()
                     : A(A.find(i, e)))

--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -2004,10 +2004,15 @@
           var a,
             n = (e = A.find(e)[0]).config,
             i = s || n.$headers,
+            l =
+              "string" == typeof i
+                ? A(A.find(i, e))
+                : A(i && i.jquery ? i.toArray() : i),
+            c = l.length ? l : n.$headers,
             d =
               (n.$headerIndexed && n.$headerIndexed[r]) ||
-              A(i).filter('[data-column="' + r + '"]:last');
-          if (void 0 !== t[r]) return o ? t[r] : t[i.index(d)];
+              c.filter('[data-column="' + r + '"]:last');
+          if (void 0 !== t[r]) return o ? t[r] : t[c.index(d)];
           for (a in t)
             if ("string" == typeof a && d.filter(a).add(d.find(a)).length)
               return t[a];


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/553](https://github.com/cooljeanius/wesnoth/security/code-scanning/553)

To fix this safely without changing intended functionality, avoid passing potentially untrusted values to the jQuery constructor in `getColumnData`. Instead of `A(i)` (which can parse HTML when `i` is a string), normalize `i` to a safe set of header elements:

- If `i` is already a jQuery object or DOM elements, keep behavior equivalent.
- If `i` is a string selector, resolve it with `A.find(i, e)` (selector-only path) and wrap the result with `A(...)`.
- If resolution fails/empty, fall back to `n.$headers`.

This change should be applied in `data/tools/addon_manager/tablesorter.js` in the `getColumnData` function around lines 2005–2010, replacing the direct `A(i)` usage and adding a normalized headers variable used for both filtering and index lookup.

No import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
