### PR TITLE
Potential fix for code scanning alert no. 550: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -1669,8 +1669,10 @@
         applyWidgetId: function (e, t, r) {
           var o,
             s,
-            a,
-            n = (e = A(e)[0]).config,
+            a;
+          e = "string" == typeof e ? A.find(e)[0] : A(e)[0];
+          if (!e || !e.config) return;
+          var n = e.config,
             i = n.widgetOptions,
             d = L.debug(n, "core"),
             l = L.getWidgetById(t);


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/550](https://github.com/cooljeanius/wesnoth/security/code-scanning/550)

The safest fix is to ensure plugin internals interpret string inputs strictly as CSS selectors (or reject non-element input), instead of passing them to `A(...)` which may parse HTML.  
Best targeted fix here: in `applyWidgetId` (around line 1673 in `data/tools/addon_manager/tablesorter.js`), replace `A(e)[0]` with `A.find(e)[0]` for string inputs, and preserve behavior for DOM/jQuery objects by normalizing first.

Concretely:
- Update `applyWidgetId` local initialization so it resolves `e` safely:
  - if `e` is a string, resolve via `A.find(e)[0]` (selector-only)
  - else resolve via `A(e)[0]` (existing behavior for elements/jQuery objects)
- Add a null guard before dereferencing `.config` to avoid runtime errors if selector matches nothing.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
