### PR TITLE
Potential fix for code scanning alert no. 546: Unsafe jQuery plugin

### DIFF
--- a/data/tools/addon_manager/tablesorter.js
+++ b/data/tools/addon_manager/tablesorter.js
@@ -418,7 +418,13 @@
                     s,
                     a,
                     n,
-                    i = A(e);
+                    i;
+                  if ("string" == typeof e) {
+                    n = A.find(e, d.table);
+                    e = n && n.length ? n[0] : null;
+                  }
+                  if (!e || !e.nodeType) return;
+                  i = A(e);
                   if (!L.getClosest(i, "tr").hasClass(d.cssIgnoreRow))
                     return (
                       /(th|td)/i.test(e.nodeName) ||


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/546](https://github.com/cooljeanius/wesnoth/security/code-scanning/546)

General fix: avoid calling the jQuery constructor on values that may be interpreted as HTML when the intent is “existing element or selector only.” Use selector-only APIs (`jQuery.find`) for strings, and wrap only real DOM nodes with `jQuery(...)`.

Best targeted fix here: in `data/tools/addon_manager/tablesorter.js`, inside `buildHeaders` map callback (around line 421), replace `i = A(e)` with guarded logic:
- If `e` is a string, resolve with `A.find(e, d.table)` and take the first result as an element (no HTML parsing).
- Else, treat `e` as element-like and wrap with `A(e)` as before.
- If resolution fails, return early from callback to preserve stability.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
