### PR TITLE
Potential fix for code scanning alert no. 933: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/irc-notify.yml
+++ b/.github/workflows/irc-notify.yml
@@ -19,7 +19,12 @@ jobs:
         env:
           MSG: ${{ github.event.head_commit.message }}
         run: |
-          printf COMMIT_SUBJECT=%s "${MSG}" | head -n 1 >> "$GITHUB_ENV"
+          DELIM="EOF_$(uuidgen)"
+          {
+            echo "COMMIT_SUBJECT<<${DELIM}"
+            printf '%s\n' "${MSG}" | head -n 1
+            echo "${DELIM}"
+          } >> "$GITHUB_ENV"
       - uses: rectalogic/notify-irc@v2
         env: {COLOR: "\x03", BLUE: "02", PURPLE: "06", ACTOR: "\x0315${{ github.actor }}\x03"}
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/933](https://github.com/cooljeanius/wesnoth/security/code-scanning/933)

Use a safe, delimiter-based multiline assignment when writing to `$GITHUB_ENV`, with a unique delimiter per run. This avoids newline injection because the value is enclosed between marker lines instead of being written as `KEY=VALUE` on one line.

Best fix in this file:
- In `.github/workflows/irc-notify.yml`, replace the current `printf ... >> "$GITHUB_ENV"` logic in the **Prepare message** step.
- Generate a random delimiter (UUID-like) and write:
  - `COMMIT_SUBJECT<<DELIM`
  - raw message content (optionally truncated to first line as currently intended)
  - `DELIM`
- Keep behavior equivalent by preserving “first line only” via `head -n 1`.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
