### PR TITLE
Potential fix for code scanning alert no. 934: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/irc-notify.yml
+++ b/.github/workflows/irc-notify.yml
@@ -19,12 +19,8 @@ jobs:
         env:
           MSG: ${{ github.event.head_commit.message }}
         run: |
-          DELIM="EOF_$(uuidgen)"
-          {
-            echo "COMMIT_SUBJECT<<${DELIM}"
-            printf '%s\n' "${MSG}" | head -n 1
-            echo "${DELIM}"
-          } >> "$GITHUB_ENV"
+          COMMIT_SUBJECT="$(printf '%s\n' "${MSG}" | head -n 1 | tr -d '\r\n')"
+          echo "COMMIT_SUBJECT=${COMMIT_SUBJECT}" >> "$GITHUB_ENV"
       - uses: rectalogic/notify-irc@v2
         env: {COLOR: "\x03", BLUE: "02", PURPLE: "06", ACTOR: "\x0315${{ github.actor }}\x03"}
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/wesnoth/security/code-scanning/934](https://github.com/cooljeanius/wesnoth/security/code-scanning/934)

Use a **single-line env assignment** instead of multiline heredoc for `COMMIT_SUBJECT`, and explicitly strip CR/LF from untrusted input before appending to `$GITHUB_ENV`.

Best fix in this file:
- In `.github/workflows/irc-notify.yml`, in the `Prepare message` step (`run` block), remove delimiter generation and heredoc writes.
- Replace with:
  1. derive first line of commit message,
  2. strip `\r` and `\n`,
  3. append as `COMMIT_SUBJECT=<sanitized>` in one line.

This preserves functionality (still uses commit subject / first line) while preventing env-file structure injection and satisfying CodeQL’s concern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
